### PR TITLE
"make install" error due to lowercase directory name "source" instead of "Source"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,7 +687,7 @@ if(BUILD_SHARED)
       LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
    )
 
-   install(FILES source/FreeImage.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+   install(FILES Source/FreeImage.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 endif()
 
 if(BUILD_STATIC)
@@ -709,5 +709,5 @@ if(BUILD_STATIC)
       LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
    )
 
-   install(FILES source/FreeImage.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+   install(FILES Source/FreeImage.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 endif()


### PR DESCRIPTION
Hi!

I get the following error during "make install":

```
+ make install
[100%] Built target freeimage_shared
Install the project...
-- Install configuration: "Release"
-- Installing: /build/freeimage-vpinball-git/pkg/freeimage-vpinball-git/usr/lib/libfreeimage.so.3.19.0
-- Installing: /build/freeimage-vpinball-git/pkg/freeimage-vpinball-git/usr/lib/libfreeimage.so
CMake Error at cmake_install.cmake:84 (file):
  file INSTALL cannot find
  "/build/freeimage-vpinball-git/src/freeimage-vpinball-git/source/FreeImage.h":
  No such file or directory.


make: *** [Makefile:100: install] Error 1
```

If I'm not mistaken, the cause seems to be a lowercase "source" instead of "Source" in the CMakeLists.txt .

With the proposed change applied, it works for me:

```
+ make install
[100%] Built target freeimage_shared
Install the project...
-- Install configuration: "Release"
-- Installing: /build/freeimage-vpinball-git/pkg/freeimage-vpinball-git/usr/lib/libfreeimage.so.3.19.0
-- Installing: /build/freeimage-vpinball-git/pkg/freeimage-vpinball-git/usr/lib/libfreeimage.so
-- Installing: /build/freeimage-vpinball-git/pkg/freeimage-vpinball-git/usr/include/FreeImage.h
+ set +x
```
